### PR TITLE
Fixes bug in replication and instance bootstrap.

### DIFF
--- a/src/log_io.cc
+++ b/src/log_io.cc
@@ -188,9 +188,8 @@ find_including_file(struct log_dir *dir, int64_t target_lsn)
 		return count;
 
 	while (count > 1) {
-		if (*lsn <= target_lsn && target_lsn < *(lsn + 1)) {
+		if (target_lsn < *(lsn + 1)) {
 			goto out;
-			return *lsn;
 		}
 		lsn++;
 		count--;

--- a/src/recovery.cc
+++ b/src/recovery.cc
@@ -529,8 +529,7 @@ recover_existing_wals(struct recovery_state *r)
 		/* No WALs to recover from. */
 		goto out;
 	}
-	r->current_wal = log_io_open_for_read(r->wal_dir, wal_lsn, NONE);
-	if (r->current_wal == NULL)
+	if (log_io_open_for_read(r->wal_dir, wal_lsn, NONE) == NULL)
 		goto out;
 	if (recover_remaining_wals(r) < 0)
 		panic("recover failed");


### PR DESCRIPTION
	Replication stop when meets gap in xlog files.
	Respects panic_on_wal_error cfg option during
	master bootstrap when entire xlog file is missing.